### PR TITLE
support merged attributes

### DIFF
--- a/src/Http/Controllers/StoreMedia.php
+++ b/src/Http/Controllers/StoreMedia.php
@@ -3,7 +3,6 @@
 namespace DmitryBubyakin\NovaMedialibraryField\Http\Controllers;
 
 use Laravel\Nova\Nova;
-use Laravel\Nova\Fields\Field;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Http\Resources\MergeValue;
 use Spatie\MediaLibrary\HasMedia\HasMedia;
@@ -54,7 +53,7 @@ class StoreMedia
             return $field instanceof MergeValue ? $field->data : $field;
         })->flatten();
 
-        return $fields->first(function (Field $field) use ($request) {
+        return $fields->first(function ($field) use ($request) {
             return $field instanceof Medialibrary && $field->collectionName == $request->collection;
         });
     }


### PR DESCRIPTION
I ran into an issue with having fields grouped in seperate methods:

```php
// Some Nova Resource

/**
     * Get the fields displayed by the resource.
     *
     * @param  \Illuminate\Http\Request  $request
     * @return array
     */
    public function fields(Request $request)
    {
        return [
            //...
            $this->addressFields(),

            Medialibrary::make('Pictures', 'pictures', Media::class)
                ->hideFromIndex(),
        ];
    }

    /**
     * Get the address fields for the resource.
     *
     * @return \Illuminate\Http\Resources\MergeValue
     */
    protected function addressFields()
    {
        return $this->merge([
            PlaceField::make('Address', 'address_line_1')->hideFromIndex(),
            Text::make('Address Line 2')->hideFromIndex(),
            Text::make('City')->hideFromIndex(),
            Text::make('State')->hideFromIndex(),
            Text::make('Postal Code')->hideFromIndex(),
            Country::make('Country')->hideFromIndex(),
            Text::make('Latitude')->hideFromIndex(),
            Text::make('Longitude')->hideFromIndex(),
        ]);
    }
```

When uploding images I got the following error

```
local.ERROR: Argument 1 passed to DmitryBubyakin\NovaMedialibraryField\Http\Controllers\StoreMedia::DmitryBubyakin\NovaMedialibraryField\Http\Controllers\{closure}() must be an instance of Laravel\Nova\Fields\Field, instance of Illuminate\Http\Resources\MergeValue given {"userId":1,"email":"admin@test.com","exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Argument 1 passed to DmitryBubyakin\\NovaMedialibraryField\\Http\\Controllers\\StoreMedia::DmitryBubyakin\\NovaMedialibraryField\\Http\\Controllers\\{closure}() must be an instance of Laravel\\Nova\\Fields\\Field, instance of Illuminate\\Http\\Resources\\MergeValue given at /home/naoray/Workspace/bitmate/tinus/mond/vendor/dmitrybubyakin/nova-medialibrary-field/src/Http/Controllers/StoreMedia.php:58)
```

Since the field's instance is already checked within the `$fields->first()` closure, IMO it's save to drop the `Field` instance in this case.