### PR TITLE
Remove trailing commas for compatibility with newer PHP versions

### DIFF
--- a/src/Fields/Medialibrary.php
+++ b/src/Fields/Medialibrary.php
@@ -266,7 +266,7 @@ class Medialibrary extends Field
             $this->attribute => MediaCollectionRules::make(
                 $rules[$this->attribute],
                 $request,
-                $this->collectionName,
+                $this->collectionName
             ),
         ];
     }

--- a/src/Fields/Support/MediaCollectionRules.php
+++ b/src/Fields/Support/MediaCollectionRules.php
@@ -21,7 +21,7 @@ class MediaCollectionRules
 
             $validator = Validator::make(
                 [$attribute => $media],
-                [$attribute => $rules],
+                [$attribute => $rules]
             );
 
             if ($validator->fails()) {

--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -66,7 +66,7 @@ class AttachController
                 TransientModel::setCustomPropertyValue(
                     $media,
                     $request->resource()::$model,
-                    $collectionName,
+                    $collectionName
                 );
             }
         });

--- a/src/Http/Controllers/CropController.php
+++ b/src/Http/Controllers/CropController.php
@@ -18,7 +18,7 @@ class CropController
                     (int) $request->width,
                     (int) $request->height,
                     (int) $request->x,
-                    (int) $request->y,
+                    (int) $request->y
                 ),
                 'orientation' => $this->orientation((int) $request->rotate),
             ],

--- a/src/Resources/Media.php
+++ b/src/Resources/Media.php
@@ -29,7 +29,7 @@ class Media extends Resource
         $field = call_user_func(new MedialibraryFieldResolver(
             $request,
             $resource,
-            $request->input('viaField'),
+            $request->input('viaField')
         ));
 
         if (is_null($field)) {

--- a/tests/Integration/AttachControllerTest.php
+++ b/tests/Integration/AttachControllerTest.php
@@ -210,7 +210,7 @@ class AttachControllerTest extends TestCase
             basename($path),
             null,
             null,
-            true,
+            true
         );
     }
 }


### PR DESCRIPTION
Would close #59 