### PR TITLE
Fix autocompletion error on Medialibrary-Field

### DIFF
--- a/src/Fields/Medialibrary.php
+++ b/src/Fields/Medialibrary.php
@@ -23,7 +23,7 @@ use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 /**
- * @method static static make(string $name, string $collectionName, string $diskName, string $attribute)
+ * @method static static make(string $name, string $collectionName = '', string $diskName = '', string $attribute = null)
  */
 class Medialibrary extends Field
 {


### PR DESCRIPTION
Currently PhpStorm only offers the default behaviour when using `Medialibrary::make` which is `$name, $attribute, $resolveCallback`. Since we have different properties on this field we should update the docs for that.

With this comment PhpStorm isn't crying anymore and we have proper autocompletion instead of marking it as wrong/error when calling `Medialibrary::make`